### PR TITLE
Add shortened titles for the nav tabs

### DIFF
--- a/content/spiffe/_index.md
+++ b/content/spiffe/_index.md
@@ -1,5 +1,6 @@
 ---
 title: SPIFFE overview
+short: Overview
 description: A basic introduction to SPIFFE, the Secure Production Identify Framework for Everyone
 weight: 1
 ---

--- a/content/spire/_index.md
+++ b/content/spire/_index.md
@@ -1,5 +1,6 @@
 ---
 title: SPIRE overview
+short: Overview
 description: A basic introduction to Spire, the SPIFFE Runtime Environment
 weight: 1
 ---

--- a/content/spire/architecture.md
+++ b/content/spire/architecture.md
@@ -1,5 +1,7 @@
 ---
 title: The architecture of SPIRE
+short: Architecture
+description: The nuts and bolts of the SPIFFE Runtime Environment
 weight: 3
 ---
 

--- a/content/spire/getting-started.md
+++ b/content/spire/getting-started.md
@@ -1,5 +1,6 @@
 ---
 title: SPIRE Getting Started Guide
+short: Getting started
 description: Install and run a SPIRE server and agent locally on your laptop
 weight: 2
 ---

--- a/layouts/partials/tabs.html
+++ b/layouts/partials/tabs.html
@@ -6,10 +6,11 @@
   <div class="container">
     <ul>
       {{- range $docs }}
+      {{- $title := cond (isset .Params "short") (.Params.short) .Title }}
       {{- $isCurrentPage := eq .URL $currentUrl }}
       <li{{ if $isCurrentPage }} class="is-active"{{ end }}>
         <a href="{{ .URL }}">
-          {{ .Title }}
+          {{ $title }}
         </a>
       </li>
       {{- end }}


### PR DESCRIPTION
This PR adds support for "short" titles, i.e. titles that appear differently in the navigation than they do at the top of the document.