### PR TITLE
Use direct Hugo commands in Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,12 @@
 [build]
 publish = "public"
-command = "make production-build"
+command = "hugo"
 
 [build.environment]
-HUGO_VERSION = "0.52"
+HUGO_VERSION = "0.53"
 
 [context.deploy-preview]
-command = "make preview-build"
+command = "hugo --baseURL $DEPLOY_PRIME_URL"
 
 [context.branch-deploy]
-command = "make preview-build"
+command = "hugo --baseURL $DEPLOY_PRIME_URL"


### PR DESCRIPTION
This is to address a thorny issue that Netlify is having updating their build infrastructure (long story). We can go back to using `make` commands once that issue is fixed.